### PR TITLE
player stats

### DIFF
--- a/project.godot
+++ b/project.godot
@@ -39,6 +39,7 @@ run/main_scene="res://Scenes/title_screen.tscn"
 
 DialogueManager="*res://addons/dialogue_manager/dialogue_manager.gd"
 GameState="*res://game_state.gd"
+PlayerStats="*res://Scenes/Player/PlayerStats.tscn"
 
 [display]
 


### PR DESCRIPTION
Player's health declines on collision with bat, but same happens for the bat - bug present
current player max_health = 6, bat - 3 - can easily be changed 