### PR TITLE
skippable dialogue

### DIFF
--- a/addons/dialogue_manager/dialogue_label.gd
+++ b/addons/dialogue_manager/dialogue_label.gd
@@ -8,7 +8,8 @@ signal finished()
 
 const DialogueLine = preload("res://addons/dialogue_manager/dialogue_line.gd")
 
-export var skip_action: String = "ui_cancel"
+# export var skip_action: String = "ui_cancel"
+export var skip_action: String = "ui_accept"
 export var seconds_per_step: float = 0.02
 
 


### PR DESCRIPTION
You can now instantly type the dialog by pressing 'ui_accept' which
currently defaults to enter

Signed-off-by: Stephen Adams <tsadams@gmail.com>